### PR TITLE
fix for the WowClassicGrindbot

### DIFF
--- a/AmeisenNavigation.Server/src/Main.hpp
+++ b/AmeisenNavigation.Server/src/Main.hpp
@@ -44,7 +44,7 @@ struct PathRequestData
     int flags;
     float start[3];
     int startBuffer; //not sure why it has extra byte, maybe antcpclient.send issue?
-    float end[3];	    float end[3];
+    float end[3];
     int endBuffer;  //not sure why it has extra byte
 };
 

--- a/AmeisenNavigation.Server/src/Main.hpp
+++ b/AmeisenNavigation.Server/src/Main.hpp
@@ -43,7 +43,9 @@ struct PathRequestData
     int mapId;
     int flags;
     float start[3];
-    float end[3];
+    int startBuffer; //not sure why it has extra byte, maybe antcpclient.send issue?
+    float end[3];	    float end[3];
+    int endBuffer;  //not sure why it has extra byte
 };
 
 struct MoveRequestData


### PR DESCRIPTION
if you select remote path v3, there's some extra integer right after start/end position