### PR TITLE
Avoid reseeding random number generator upon calling GetRandomFloat.

### DIFF
--- a/AmeisenNavigation/src/AmeisenNavigation.hpp
+++ b/AmeisenNavigation/src/AmeisenNavigation.hpp
@@ -42,11 +42,12 @@
 // macro to print all values of a vector3
 #define PRINT_VEC3(vec) "[" << vec.x << ", " << vec.y << ", " << vec.z << "]"
 
+static std::random_device rd;
+static std::mt19937 rng(rd());
+static std::uniform_real_distribution<float> dis{ 0.0f, 1.0f };
+
 static float GetRandomFloat() noexcept
 {
-    static std::random_device rd;
-    static std::mt19937 rng(rd());
-    static std::uniform_real_distribution<float> dis{ 0.0f, 1.0f };
     return dis(rng);
 }
 


### PR DESCRIPTION
It looks like your code is almost correct for generating random float numbers.

However, there might be an issue due to the fact that you're reseeding the random number generator (`std::mt19937`) every time you call the function.

By reseeding it with `rd()`, you're essentially using the same seed every time, which results in the same sequence of random numbers being generated.

To fix this, you should only seed the random number generator once.

You can achieve this by making `std::mt19937` and `std::uniform_real_distribution<float>` static variables outside the function.